### PR TITLE
イベント表示順を降順にする

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,2 +1,3 @@
 class Event < ApplicationRecord
+  default_scope -> { order(created_at: :desc) }
 end

--- a/test/fixtures/events.yml
+++ b/test/fixtures/events.yml
@@ -1,5 +1,3 @@
-# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
-
 one:
   title: MyText
   sub_title: MyText
@@ -9,6 +7,7 @@ one:
   start_time: 2017-05-27 17:22:46
   end_time: 2017-05-27 17:22:46
   capacity: 1
+  created_at: <%= 2.years.ago %>
 
 two:
   title: MyText
@@ -19,3 +18,15 @@ two:
   start_time: 2017-05-27 17:22:46
   end_time: 2017-05-27 17:22:46
   capacity: 1
+  created_at: <%= 1.hours.ago %>
+
+most_recent:
+  title: recent_title
+  sub_title: recent_sub_title
+  description: recent_description
+  location: recent_location
+  image_url: recent_image_url
+  start_time: <%= Time.zone.now %>
+  end_time: <%= Time.zone.now %>
+  capacity: 10
+  created_at: <%= Time.zone.now %>

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class EventTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "order should be most recent first" do
+    assert_equal events(:most_recent), Event.first
+  end
 end


### PR DESCRIPTION
https://github.com/yutokyokutyo/MICS-Event-Management/issues/8

新着イベントは上に来てほしい。